### PR TITLE
add performance metrics and start_chat, finish_chat

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,7 +1,7 @@
 import openvino_genai
 import time
 
-model_path = "/mnt/Ironwolf-4TB/Models/OpenVINO/Qwen/Qwen3-1.7B-int8_asym-ov"
+model_path = "Llama3B-ov"
 
 # Use NPU+GPU if available
 pipe = openvino_genai.LLMPipeline(model_path, "CPU")

--- a/run.py
+++ b/run.py
@@ -1,16 +1,17 @@
 import openvino_genai
-import sys
 import time
 
-model_path = "Llama3B-ov"
+model_path = "/mnt/Ironwolf-4TB/Models/OpenVINO/Qwen/Qwen3-1.7B-int8_asym-ov"
 
 # Use NPU+GPU if available
-pipe = openvino_genai.LLMPipeline(model_path, "NPU")
+pipe = openvino_genai.LLMPipeline(model_path, "CPU")
 
 config = openvino_genai.GenerationConfig()
 config.max_new_tokens = 20000
 
 print("Chatbot ready! Type 'exit' to quit.\n")
+
+pipe.start_chat()
 
 while True:
     user_input = input("You: ")
@@ -24,6 +25,29 @@ while True:
         print(token_text, end="", flush=True)  # live typing
         time.sleep(0.02)  # optional delay for human-like typing effect
 
-    # Generate with streaming
-    pipe.generate(user_input, config, stream_callback)
+    # Generate with streaming and capture result to access perf_metrics
+    result = pipe.generate([user_input], config, stream_callback)
+
+    performance_report = result.perf_metrics
+
+    performance_report = {
+        'load_time (s)': round(performance_report.get_load_time() / 1000, 2), # time to load the model
+        'ttft (s)': round(performance_report.get_ttft().mean / 1000, 2), # time to first token
+        'tpot (ms)': round(performance_report.get_tpot().mean, 2), # time to process one token
+        'throughput (tokens/s)': round(performance_report.get_throughput().mean, 2), # tokens per second (throughput)
+        'generate_duration (s)': round(performance_report.get_generate_duration().mean / 1000, 2), # time to generate the response
+        'input_tokens': performance_report.get_num_input_tokens(), # number of input tokens
+        'new_tokens': performance_report.get_num_generated_tokens(), # number of new tokens generated
+        'total_tokens': performance_report.get_num_input_tokens() + performance_report.get_num_generated_tokens(), # total number of tokens
+        }
+
+    # Formatted performance metrics
+    print("\nPerformance metrics:")
+    print("-" * 40)
+    key_width = max(len(key) for key in performance_report.keys())
+    for key, value in performance_report.items():
+        print(f"  {key.ljust(key_width)} : {value}")
+
     print("\n")  # newline after response
+
+pipe.finish_chat()


### PR DESCRIPTION
Hello @balaragavan2007,

I was the guy who posted on Reddit about his project [OpenArc](https://github.com/SearchSavior/OpenArc).

Thank you for publishing this project!  We need more people to try NPU devices, and share real world performance to demonstrate progress going on behind the scenes. 

# What does this PR do?

- adds a performance metrics report after every completion

```
Qwen3-1.7B-int8_asym-ov on Xeon W-2255  

load_time (s)         : 0.96  # time to load model into memory
  ttft (s)              : 0.07  # time to first token
  tpot (ms)             : 38.39 # per token latency 
  throughput (tokens/s) : 26.05 # generation throughput
  generate_duration (s) : 4.34 
  input_tokens          : 125
  new_tokens            : 111
  total_tokens          : 236
```

- introduces [start_chat() and finish_chat()](https://openvinotoolkit.github.io/openvino.genai/docs/guides/chat-scenario), which maintains context. Before this, messages did not track across context.


# Suggestions

- add argparse, so you can launch the script from the command line with arguments like --model --device --max_new_tokens. Try to hardcode as few values as possible. 
- remove download.py, you provide a download command
- more descriptive name for the env like "ov_npu" or "bala_npu"


Now that you can track performance of NPU device, hopefully you can publish some benchmarks on Reddit! 
